### PR TITLE
cube, scvm에 blackbox_exporter 포트 삭제, mold smtp 설정 추가 개발

### DIFF
--- a/python/config_prometheus.py
+++ b/python/config_prometheus.py
@@ -125,14 +125,14 @@ def ccvmProcessConfig(ccvm_ip):
 def cubeBlackboxConfig(cube_ip):
     cube = cube_ip.copy()
     for i in range(len(cube)):
-        cube[i] = cube[i] + blackbox_exporter_port
+        cube[i] = cube[i]
     return cube
 
 
 def scvmBlackboxConfig(scvm_ip):
     scvm = scvm_ip.copy()
     for i in range(len(scvm)):
-        scvm[i] = scvm[i] + blackbox_exporter_port
+        scvm[i] = scvm[i]
     return scvm
 
 
@@ -208,7 +208,7 @@ def configYaml(cube, scvm, ccvm):
 
         elif prometheus_org['scrape_configs'][i]['job_name'] == 'blackbox-tcp':
             prometheus_org['scrape_configs'][i]['static_configs'][0]['targets'] = cubeServiceConfig(cube) + moldServiceConfig(ccvm) + moldDBConfig(ccvm) + libvirtConfig(cube) + cubeNodeConfig(cube) + scvmNodeConfig(scvm) + ccvmNodeConfig(
-                ccvm) + cubeProcessConfig(cube) + scvmProcessConfig(scvm) + ccvmProcessConfig(ccvm) + cubeBlackboxConfig(cube) + scvmBlackboxConfig(scvm) + ccvmBlackboxConfig(ccvm)
+                ccvm) + cubeProcessConfig(cube) + scvmProcessConfig(scvm) + ccvmProcessConfig(ccvm) + ccvmBlackboxConfig(ccvm)
             prometheus_org['scrape_configs'][i]['relabel_configs'][-1]['replacement'] = ccvmBlackboxConfig(
                 ccvm)[0]
 

--- a/python/config_prometheus.py
+++ b/python/config_prometheus.py
@@ -11,7 +11,7 @@ import yaml
 import argparse
 import json
 from ablestack import *
-
+import configparser
 
 # prometheus에서 수집하는 exporter 및 서비스 포트
 # prometheus_port = ":3001"
@@ -216,12 +216,28 @@ def configYaml(cube, scvm, ccvm):
             yaml_file.write(
                 yaml.dump(prometheus_org, default_flow_style=False))
 
+# 함수명 : configIni
+# 주요 기능 : grafana의 설정 파일에 도메인을 ccvm ip로 설정
+
+
+def configIni(ccvm):
+    ini_file = '/usr/share/ablestack/ablestack-wall/grafana/conf/defaults.ini'
+    config = configparser.ConfigParser()
+
+    config.read(ini_file)
+
+    config.set('server', 'domain', ccvm[0])
+
+    with open(ini_file, 'w') as f:
+        config.write(f)
+
 
 def main():
     args = parseArgs()
 
     if (args.action) == 'config':
         configYaml(args.cube, args.scvm, args.ccvm)
+        configIni(args.ccvm)
 
     ret = createReturn(code=200, val="update prometheus")
     print(json.dumps(json.loads(ret), indent=4))

--- a/python/start_services.py
+++ b/python/start_services.py
@@ -19,7 +19,7 @@ def parseArgs():
                                      epilog='copyrightⓒ 2021 All rights reserved by ABLECLOUD™')
 
     parser.add_argument('action', choices=[
-                        'start', 'stop'], help='choose one of the actions')
+                        'start', 'stop', 'restart'], help='choose one of the actions')
     parser.add_argument('--service', metavar='name', type=str,
                         nargs='*', help='want to start service name')
 
@@ -27,11 +27,15 @@ def parseArgs():
 
 
 def startServices(service):
-    print(systemctl('enable', '--now', service))
+    systemctl('enable', '--now', service)
 
 
 def stopServices(service):
-    print(systemctl('disable', '--now', service))
+    systemctl('disable', '--now', service)
+
+
+def restartServices(service):
+    systemctl('restart', service)
 
 
 def main():
@@ -55,6 +59,16 @@ def main():
 
         except Exception as e:
             ret = createReturn(code=500, val="fail to stop service")
+            print(json.dumps(json.loads(ret), indent=4))
+
+    elif (args.action) == 'restart':
+        try:
+            restartServices(args.service)
+            ret = createReturn(code=200, val="services are restarted")
+            print(json.dumps(json.loads(ret), indent=4))
+
+        except Exception as e:
+            ret = createReturn(code=500, val="fail to restart service")
             print(json.dumps(json.loads(ret), indent=4))
 
     return ret


### PR DESCRIPTION
#46 #48 

- [x] 버그 수정 (cube, scvm의 blackbox_exporter 삭제)
- [x] Mold smtp 설정 함수 개발
- [x] 서비스 restart 옵션 추가

1. cube, scvm은 blackbox exporter가 설치되지 않고 사용되지 않아 blackbox_exporter 포트로 데이터를 조회 했을 때 대시보드 패널이 정상적으로 표시 되지 않는 문제가 발견되었습니다.
포트를 삭제하고 ip로 조회할 수 있도록 변경했습니다.

2. Wall 서비스 배포의 smtp 설정 단계에서 Mold의 smtp 설정도 입력받은 값으로 변경할 수 있도록 하는 소스 개발을 완료했습니다.