### PR TITLE
Wall 서비스 구성 파일(config_wall.py) 테스트 코드 삭제

### DIFF
--- a/python/config_wall.py
+++ b/python/config_wall.py
@@ -257,10 +257,6 @@ def configDS(scvm, ccvm):
     cur.execute(ds_update_query4)
 
     conn.commit()
-
-    cur.execute('SELECT * FROM data_source')
-    for row in cur:
-        print(row)
     conn.close()
 
 


### PR DESCRIPTION
#51 
Wall 서비스 배포 단계에서 json 코드 값을 리턴해야 하나 테스트 코드가 포함되어 출력되는 문제가 있어,
쿼리 내용을 출력하는 라인을 삭제했습니다.

- [x] grafana.db 업데이트 내용 출력 테스트 코드 삭제