### PR TITLE
Wall 서비스 배포 시 서비스 이름이 잘못되어 구성에 실패하는 문제 해결

### DIFF
--- a/python/config_smtp.py
+++ b/python/config_smtp.py
@@ -53,7 +53,7 @@ def configWallSmtp(host, user, password):
     with open(ini_file, 'w') as f:
         config.write(f)
 
-    systemctl('restart', 'grafana')
+    systemctl('restart', 'grafana-server')
 
 
 def configMoldSmtp(host, user, password):


### PR DESCRIPTION
### PR 설명

#54 

이 PR은 Wall 서비스 배포 시 서비스 이름이 잘못 되어 정상적으로 서비스를 실행할 수 없어 Wall 서비스 배포가 실패하는 문제를 해결한 내용입니다.

<!--- 변경 사항에 대해 자세하게 설명하십시오. 그리고 변경사항을 어떻게 실행하는지도 설명합니다. -->
grafana -> garfana-server 로 변경

<!-- 새로운 기능에 대한 PR인 경우, 타당성 조사(FS) 및 디자인 컨셉(DS) 등에 대한 위키 또는 문서 등을 링크합니다. -->
<!-- 버그 수정에 대한 PR인 경우, 재현을 위한 과정과 기대 실행 및 실제 실행 결과에 대한 내용을 설명합니다. -->

<!-- "Fixes #<id>"를 사용하면 해당 이슈 및 PR이 관련 이슈/PR로 등록되어 PR이 Merge 될 때 자동으로 종료됩니다. -->
<!-- 여려 개의 이슈 또는 PR을 지정하고자 하는 경우, 여러 개의 "Fixes #<id>"를 작성합니다. -->
<!-- Fixes # -->


### 변경 구분

- [x] 버그 수정 (이슈에 보고된 버그에 대한 수정으로 다른 기능에 영향을 미치지 않음)

### 기능/개선 규모 또는 버그 심각도

#### 기능/개선 규모

- [x] 소규모 기능/개선

#### 버그 심각도

- [x] 매우 심각 (제품 출시/운영을 불가능하게 함)



### 스크린샷


### 테스트 방법 및 결과
<!-- 변경사항에 대해 어떻게 테스트 되었는지 상세하게 기재합니다. -->
<!-- 테스트 환경, 실행 구성 등을 자세하게 내용에 포함합니다. -->
<!-- 변경사항이 영향을 미치는 다른 영역, 예를 들어 화면, 코드 등을 같이 볼 수 있도록 합니다. -->


