### PR TITLE
Prometheus 데이터 수집 최대 90일, 저장 용량 최대 60GB 까지 수집 가능하도록 설정 변경

### DIFF
--- a/systemds/vm/prometheus.service
+++ b/systemds/vm/prometheus.service
@@ -9,7 +9,7 @@ Restart=on-failure
 
 ExecStart=/usr/share/ablestack/ablestack-wall/prometheus/prometheus \
     --config.file=/usr/share/ablestack/ablestack-wall/prometheus/prometheus.yml \
-    --storage.tsdb.path=/data/prometheus \
+    --storage.tsdb.path=/nfs/primary/prometheus \
     --web.console.templates=/usr/share/ablestack/ablestack-wall/prometheus/consoles \
     --web.console.libraries=/usr/share/ablestack/ablestack-wall/prometheus/console_libraries \
     --web.listen-address=0.0.0.0:3001 \

--- a/systemds/vm/prometheus.service
+++ b/systemds/vm/prometheus.service
@@ -13,7 +13,9 @@ ExecStart=/usr/share/ablestack/ablestack-wall/prometheus/prometheus \
     --web.console.templates=/usr/share/ablestack/ablestack-wall/prometheus/consoles \
     --web.console.libraries=/usr/share/ablestack/ablestack-wall/prometheus/console_libraries \
     --web.listen-address=0.0.0.0:3001 \
-    --web.enable-admin-api
+    --web.enable-admin-api \
+    --storage.tsdb.retention.time=90d \
+    --storage.tsdb.retention.size=60GB
 
 [Install]
 WantedBy=multi-user.target

--- a/systemds/vm/prometheus.service
+++ b/systemds/vm/prometheus.service
@@ -9,7 +9,7 @@ Restart=on-failure
 
 ExecStart=/usr/share/ablestack/ablestack-wall/prometheus/prometheus \
     --config.file=/usr/share/ablestack/ablestack-wall/prometheus/prometheus.yml \
-    --storage.tsdb.path=/nfs/primary/prometheus \
+    --storage.tsdb.path=/nfs/prometheus \
     --web.console.templates=/usr/share/ablestack/ablestack-wall/prometheus/consoles \
     --web.console.libraries=/usr/share/ablestack/ablestack-wall/prometheus/console_libraries \
     --web.listen-address=0.0.0.0:3001 \


### PR DESCRIPTION
Prometheus 데이터 수집 최대 90일, 저장 용량 최대 60GB 까지 수집 가능하도록 설정 변경

- 수집기간 90일 또는 저장용량 최대 60GB에 먼저 도달하는 경우에 따라 모니터링 데이터를 수집한다.
- prometheus 데이터 저장위치 /data/prometheus 에서 /nfs/prometheus 로 변경